### PR TITLE
Removed empty entries from franchises table

### DIFF
--- a/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
@@ -184,22 +184,41 @@ public class Game implements DbModelObj {
    *
    * @return String
    */
-
   @Override
   public String toString() {
-    return "Game{" +
-        "gid=" + gid +
-        ", gname='" + gname + '\'' +
-        ", cost='" + cost + '\'' +
-        ", discountedCost='" + discountedCost + '\'' +
-        ", url='" + url + '\'' +
-        ", age_rating='" + age_rating + '\'' +
-        ", indie=" + indie +
-        ", description='" + description + '\'' +
-        ", genres=" + genres +
-        ", release_date='" + release_date + '\'' +
-        ", rawgId=" + rawgId +
-        ", franchise='" + franchise + '\'' +
-        '}';
+    return "Game{"
+        + "gid="
+        + gid
+        + ", gname='"
+        + gname
+        + '\''
+        + ", cost='"
+        + cost
+        + '\''
+        + ", discountedCost='"
+        + discountedCost
+        + '\''
+        + ", url='"
+        + url
+        + '\''
+        + ", age_rating='"
+        + age_rating
+        + '\''
+        + ", indie="
+        + indie
+        + ", description='"
+        + description
+        + '\''
+        + ", genres="
+        + genres
+        + ", release_date='"
+        + release_date
+        + '\''
+        + ", rawgId="
+        + rawgId
+        + ", franchise='"
+        + franchise
+        + '\''
+        + '}';
   }
 }

--- a/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
@@ -3,8 +3,6 @@ package com.StruckCroissant.GameDB.core.game;
 import com.StruckCroissant.GameDB.core.DbModelObj;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 /**
  * Provides a game db object for completing transactions within the API.
@@ -13,15 +11,15 @@ import javax.validation.constraints.NotNull;
  * @since 2022-06-20
  */
 public class Game implements DbModelObj {
-  @NotNull private final int gid;
+  private final int gid;
 
-  @NotBlank private final String gname;
+  private final String gname;
 
   private final String cost;
 
   private final String discountedCost;
 
-  @NotBlank private final String url;
+  private final String url;
 
   private final String age_rating;
 
@@ -33,7 +31,7 @@ public class Game implements DbModelObj {
 
   private final String release_date;
 
-  @NotBlank private final float rawgId;
+  private final float rawgId;
 
   private final String franchise;
 

--- a/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/Game.java
@@ -35,6 +35,8 @@ public class Game implements DbModelObj {
 
   @NotBlank private final float rawgId;
 
+  private final String franchise;
+
   /**
    * Constructor creates a new game object from parameters
    *
@@ -46,7 +48,8 @@ public class Game implements DbModelObj {
    * @param ageRating game age rating
    * @param indie game indie status (T/F)
    * @param description game description
-   * @param genres
+   * @param genres game genres
+   * @param franchise game franchise
    * @param releaseDate game release date
    * @param rawgId game rawg ID
    */
@@ -60,6 +63,7 @@ public class Game implements DbModelObj {
       @JsonProperty("indie") int indie,
       @JsonProperty("description") String description,
       List<String> genres,
+      @JsonProperty("franchise") String franchise,
       @JsonProperty("releaseDate") String releaseDate,
       @JsonProperty("rawgId") float rawgId) {
     this.gid = gid;
@@ -71,6 +75,7 @@ public class Game implements DbModelObj {
     this.indie = indie;
     this.description = description;
     this.genres = genres;
+    this.franchise = franchise;
     this.release_date = releaseDate;
     this.rawgId = rawgId;
   }
@@ -157,6 +162,15 @@ public class Game implements DbModelObj {
   }
 
   /**
+   * returns franchise
+   *
+   * @return String franchise
+   */
+  public String getFranchise() {
+    return franchise;
+  }
+
+  /**
    * returns rawg id
    *
    * @return float rawgId
@@ -170,33 +184,22 @@ public class Game implements DbModelObj {
    *
    * @return String
    */
+
   @Override
   public String toString() {
-    return "Game{"
-        + "gid="
-        + gid
-        + ", gname='"
-        + gname
-        + '\''
-        + ", cost='"
-        + cost
-        + '\''
-        + ", discountedCost='"
-        + discountedCost
-        + '\''
-        + ", url='"
-        + url
-        + '\''
-        + ", age_rating="
-        + age_rating
-        + ", description='"
-        + description
-        + '\''
-        + ", release_date='"
-        + release_date
-        + '\''
-        + ", rawgId="
-        + rawgId
-        + '}';
+    return "Game{" +
+        "gid=" + gid +
+        ", gname='" + gname + '\'' +
+        ", cost='" + cost + '\'' +
+        ", discountedCost='" + discountedCost + '\'' +
+        ", url='" + url + '\'' +
+        ", age_rating='" + age_rating + '\'' +
+        ", indie=" + indie +
+        ", description='" + description + '\'' +
+        ", genres=" + genres +
+        ", release_date='" + release_date + '\'' +
+        ", rawgId=" + rawgId +
+        ", franchise='" + franchise + '\'' +
+        '}';
   }
 }

--- a/api/main/java/com/StruckCroissant/GameDB/core/game/GameDAOImpl.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/GameDAOImpl.java
@@ -1,8 +1,5 @@
 package com.StruckCroissant.GameDB.core.game;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +47,7 @@ public class GameDAOImpl implements GameDao {
         g.indie,
         g.description,
         GROUP_CONCAT(gn.genre_name) as genres,
+        f.fname as franchise,
         g.rdate,
         g.rawgId
     FROM
@@ -57,10 +55,12 @@ public class GameDAOImpl implements GameDao {
             g.gid = ggn.gid
         LEFT JOIN genre gn ON
             gn.genre_id = ggn.genre_id
+        LEFT JOIN franchise f ON
+            g.gid = f.gid
     GROUP BY g.gid
     ;
     """;
-    return jdbcTemplate.query(sql, (resultSet, i) -> getGameFromResultSet(resultSet));
+    return jdbcTemplate.query(sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet));
   }
 
   /**
@@ -83,6 +83,7 @@ public class GameDAOImpl implements GameDao {
         g.indie,
         g.description,
         GROUP_CONCAT(gn.genre_name) as genres,
+        f.fname as franchise,
         g.rdate,
         g.rawgId
     FROM
@@ -90,6 +91,8 @@ public class GameDAOImpl implements GameDao {
             g.gid = ggn.gid
         LEFT JOIN genre gn ON
             gn.genre_id = ggn.genre_id
+        LEFT JOIN franchise f ON
+            g.gid = f.gid
     WHERE g.gid = ?
     GROUP BY
         g.gid
@@ -101,7 +104,7 @@ public class GameDAOImpl implements GameDao {
             sql,
             (resultSet) -> {
               if (resultSet.next()) {
-                return getGameFromResultSet(resultSet);
+                return SQLGameAccessor.getGameFromResultSet(resultSet);
               } else {
                 return null;
               }
@@ -124,7 +127,8 @@ public class GameDAOImpl implements GameDao {
             g.description,
             g.rdate,
             g.rawgId,
-            group_concat(gen.genre_name) AS genres
+            group_concat(gen.genre_name) AS genres,
+            f.fname as franchise
         FROM
             gamegenre gm1 INNER JOIN
               gamegenre gm2 ON
@@ -133,51 +137,14 @@ public class GameDAOImpl implements GameDao {
               game g ON gm2.gid = g.gid
             INNER JOIN
               genre gen on gm2.genre_id = gen.genre_id
+            LEFT JOIN franchise f ON
+              g.gid = f.gid
         WHERE
             gm1.gid = ?
         group by gm2.gid
         order by COUNT(gm2.genre_id) DESC
         LIMIT 10;
        """;
-    return jdbcTemplate.query(SQL, (resultSet, i) -> getGameFromResultSet(resultSet), id);
-  }
-
-  /**
-   * Private method that extracts game object from resultSet
-   *
-   * @param resultSet jdbcTemplate resultSet cursor
-   * @return Game
-   * @throws SQLException generic SQL exception
-   */
-  private Game getGameFromResultSet(ResultSet resultSet) throws SQLException {
-    int gid = resultSet.getInt("gid");
-    String gname = resultSet.getString("gname");
-    String cost = resultSet.getString("cost");
-    String discountedCost = resultSet.getString("discounted_cost");
-    String url = resultSet.getString("url");
-    String ageRating = resultSet.getString("age_rating");
-    int indie = resultSet.getInt("indie");
-    String description = resultSet.getString("description");
-    String rdate = resultSet.getString("rdate");
-    float rawgId = resultSet.getFloat("rawgId");
-    String genresJoined = resultSet.getString("genres");
-
-    List<String> genres = List.of("NULL");
-    if (genresJoined != null) {
-      genres = Arrays.asList(genresJoined.split(","));
-    }
-
-    return new Game(
-        gid,
-        gname,
-        cost,
-        discountedCost,
-        url,
-        ageRating,
-        indie,
-        description,
-        genres,
-        rdate,
-        rawgId);
+    return jdbcTemplate.query(SQL, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), id);
   }
 }

--- a/api/main/java/com/StruckCroissant/GameDB/core/game/GameDAOImpl.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/GameDAOImpl.java
@@ -60,7 +60,8 @@ public class GameDAOImpl implements GameDao {
     GROUP BY g.gid
     ;
     """;
-    return jdbcTemplate.query(sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet));
+    return jdbcTemplate.query(
+        sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet));
   }
 
   /**
@@ -145,6 +146,7 @@ public class GameDAOImpl implements GameDao {
         order by COUNT(gm2.genre_id) DESC
         LIMIT 10;
        """;
-    return jdbcTemplate.query(SQL, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), id);
+    return jdbcTemplate.query(
+        SQL, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), id);
   }
 }

--- a/api/main/java/com/StruckCroissant/GameDB/core/game/SQLGameAccessor.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/game/SQLGameAccessor.java
@@ -1,0 +1,50 @@
+package com.StruckCroissant.GameDB.core.game;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SQLGameAccessor {
+  /**
+   * Private method that extracts game object from resultSet
+   *
+   * @param resultSet jdbcTemplate resultSet cursor
+   * @return Game
+   * @throws SQLException generic SQL exception
+   */
+  public static Game getGameFromResultSet(ResultSet resultSet) throws SQLException {
+    int gid = resultSet.getInt("gid");
+    String gname = resultSet.getString("gname");
+    String cost = resultSet.getString("cost");
+    String discountedCost = resultSet.getString("discounted_cost");
+    String url = resultSet.getString("url");
+    String ageRating = resultSet.getString("age_rating");
+    int indie = resultSet.getInt("indie");
+    String description = resultSet.getString("description");
+    String rdate = resultSet.getString("rdate");
+    float rawgId = resultSet.getFloat("rawgId");
+    String genresJoined = resultSet.getString("genres");
+    String franchise = resultSet.getString("franchise");
+
+    List<String> genres = new ArrayList<>();
+    if (genresJoined != null) {
+      genres = Arrays.asList(genresJoined.split(","));
+    }
+
+    return new Game(
+        gid,
+        gname,
+        cost,
+        discountedCost,
+        url,
+        ageRating,
+        indie,
+        description,
+        genres,
+        franchise,
+        rdate,
+        rawgId);
+  }
+}

--- a/api/main/java/com/StruckCroissant/GameDB/core/user/UserDAOImpl.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/user/UserDAOImpl.java
@@ -3,9 +3,10 @@ package com.StruckCroissant.GameDB.core.user;
 import com.StruckCroissant.GameDB.core.game.Game;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import com.StruckCroissant.GameDB.core.game.SQLGameAccessor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -111,6 +112,7 @@ public class UserDAOImpl implements UserDao {
         g.indie,
         g.description,
         GROUP_CONCAT(gn.genre_name) as genres,
+        f.fname as franchise,
         g.rdate,
         g.rawgId
     FROM
@@ -118,11 +120,13 @@ public class UserDAOImpl implements UserDao {
             g.gid = ggn.gid
         LEFT JOIN genre gn ON
             gn.genre_id = ggn.genre_id
+        LEFT JOIN franchise f ON
+            g.gid = f.gid
         INNER JOIN plays p ON g.gid = p.gid
         INNER JOIN user u ON p.uid = u.uid
     WHERE u.uid = ?;
     """;
-    return jdbcTemplate.query(sql, (resultSet, i) -> getGameFromResultSet(resultSet), uid);
+    return jdbcTemplate.query(sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), uid);
   }
 
   @Override
@@ -211,37 +215,5 @@ public class UserDAOImpl implements UserDao {
             uid);
     assert amnt != null;
     return amnt == 0;
-  }
-
-  private Game getGameFromResultSet(ResultSet resultSet) throws SQLException {
-    int gid = resultSet.getInt("gid");
-    String gname = resultSet.getString("gname");
-    String cost = resultSet.getString("cost");
-    String discountedCost = resultSet.getString("discounted_cost");
-    String url = resultSet.getString("url");
-    String ageRating = resultSet.getString("age_rating");
-    int indie = resultSet.getInt("indie");
-    String description = resultSet.getString("description");
-    String genresJoined = resultSet.getString("genres");
-    String rdate = resultSet.getString("rdate");
-    float rawgId = resultSet.getFloat("rawgId");
-
-    List<String> genres = List.of("NULL");
-    if (genresJoined != null) {
-      genres = Arrays.asList(genresJoined.split(","));
-    }
-
-    return new Game(
-        gid,
-        gname,
-        cost,
-        discountedCost,
-        url,
-        ageRating,
-        indie,
-        description,
-        genres,
-        rdate,
-        rawgId);
   }
 }

--- a/api/main/java/com/StruckCroissant/GameDB/core/user/UserDAOImpl.java
+++ b/api/main/java/com/StruckCroissant/GameDB/core/user/UserDAOImpl.java
@@ -1,12 +1,11 @@
 package com.StruckCroissant.GameDB.core.user;
 
 import com.StruckCroissant.GameDB.core.game.Game;
+import com.StruckCroissant.GameDB.core.game.SQLGameAccessor;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
-
-import com.StruckCroissant.GameDB.core.game.SQLGameAccessor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -126,7 +125,8 @@ public class UserDAOImpl implements UserDao {
         INNER JOIN user u ON p.uid = u.uid
     WHERE u.uid = ?;
     """;
-    return jdbcTemplate.query(sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), uid);
+    return jdbcTemplate.query(
+        sql, (resultSet, i) -> SQLGameAccessor.getGameFromResultSet(resultSet), uid);
   }
 
   @Override

--- a/api/test/java/com/StruckCroissant/GameDB/core/game/GameServiceTest.java
+++ b/api/test/java/com/StruckCroissant/GameDB/core/game/GameServiceTest.java
@@ -103,6 +103,7 @@ public class GameServiceTest {
         1,
         "Desc",
         Arrays.asList("Action", "Adventure"),
+        "franchise",
         "rdate",
         26890);
   }

--- a/api/test/java/com/StruckCroissant/GameDB/core/user/UserControllerTest.java
+++ b/api/test/java/com/StruckCroissant/GameDB/core/user/UserControllerTest.java
@@ -126,6 +126,7 @@ public class UserControllerTest {
             null,
             Arrays.asList("Action", "Adventure"),
             null,
+            "Test franchise",
             42069);
     when(userService.getSavedGames(UID)).thenReturn(List.of(GAME));
 


### PR DESCRIPTION
Closes #44 

### Changes:
1. Add franchise list on returned game object
2. Remove empty entries on franchise table
3. Make genre list return empty list instead of a single-valued list containing "NULL"